### PR TITLE
Wrap chdir calls, small spec fix

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,2 @@
-require 'Forgery'
+require 'forgery'
 require 'tmpdir'


### PR DESCRIPTION
Thanks for this gem.  I've made a small patch:

There are two commits:
- The lib for Forgery is apparently 'forgery'; I changed a require in the spec helper.  I don't know if you're on a case-insensitive FS, or perhaps a previous version of Forgery used the capitalized filename.
- I wrapped calls to Dir.chdir.  It's not any more thread-safe than it was before, but it does ensure that, by the time the call is finished, we'll be back in the previous directory.  (I'm going to try using this on a web service, and the application may get frustrated if the cwd moves around.)
