### PR TITLE
fixed execution of add_repo and rm_repo example in README.rdoc.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -39,10 +39,10 @@ This method can only be called on an existing gitolite-admin repo.  If you need 
   repo.add_permission("RW+", "", "bob", "joe", "susan")
 
   #Add repo
-  ga_repo.add_repo(repo)
+  ga_repo.config.add_repo(repo)
 
   #Delete repo
-  ga_repo.rm_repo(repo)
+  ga_repo.config.rm_repo(repo)
 
 === SSH Key Management
 


### PR DESCRIPTION
Please, consider to merge this changes to fix a mistake in README.rdoc.

Thank you for this gem! ;)
