### PR TITLE
Fix for ruby 1.8.7

### DIFF
--- a/lib/gitolite/config.rb
+++ b/lib/gitolite/config.rb
@@ -213,8 +213,7 @@ module Gitolite
           dp.add_vertex! group
 
           # Select group names from the users
-          subgroups = group.users.select {|u| u =~ /^#{Group::PREPEND_CHAR}.*$/}
-                                 .map{|g| get_group g.gsub(Group::PREPEND_CHAR, '') }
+          subgroups = group.users.select {|u| u =~ /^#{Group::PREPEND_CHAR}.*$/}.map{|g| get_group g.gsub(Group::PREPEND_CHAR, '') }
 
           subgroups.each do |subgroup|
             dp.add_edge! subgroup, group


### PR DESCRIPTION
Tried to install on my ruby 1.8.7 machine and had this error:

``` ruby
/opt/ruby-enterprise/lib/ruby/gems/1.8/gems/gitolite-1.0.1/lib/gitolite/config.rb:214: syntax error, unexpected '.', expecting kEND
...                             .map{|g| get_group g.gsub(Group...
                              ^
```
