### PR TITLE
Simplify gitolite.conf diffs by sorting repos and adding blank lines

### DIFF
--- a/lib/gitolite/config.rb
+++ b/lib/gitolite/config.rb
@@ -72,13 +72,15 @@ module Gitolite
         dep_order.each {|group| f.write group.to_s }
 
         gitweb_descs = []
-        @repos.each do |k, v|
+        @repos.sort.each do |k, v|
+          f.write "\n"
           f.write v.to_s
 
           gwd = v.gitweb_description
           gitweb_descs.push(gwd) unless gwd.nil?
         end
 
+        f.write "\n"
         f.write gitweb_descs.join("\n")
       end
 


### PR DESCRIPTION
The original code changed the order of the entire gitolite.conf file
after every commit; this meant that diffs (for e.g. security audits)
were essentially useless.  This fix includes two small changes that
improve this situation greatly:
- Sort the repo list on output (including gitweb description lines)
  so that (mostly) only changed repos show up in the diff
- Add a blank line between each repo block and each file section, so
  that `git diff` will not be confused and make a single-line change
  to a repo's permissions appear to be a cascading reordering of lines
  across several consecutive repos with similar permissions

The latter change also has the side benefit of making the conf file
(and thus the diffs) more readable to humans.

Still remaining to fix is the constant reordering of group definitions
when there exists no unique dependency ordering between them.
